### PR TITLE
Format genres

### DIFF
--- a/file-format-types.rdf
+++ b/file-format-types.rdf
@@ -1,0 +1,186 @@
+<?xml version="1.0"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+  xmlns:owl="http://www.w3.org/2002/07/owl#"
+  xmlns:udfrs="http://www.udfr.org/onto#">
+  <owl:Ontology rdf:about="http://pcdm.org/file-format-types#">
+    <rdfs:comment xml:lang="en">PCDM File Format Genre ontology.</rdfs:comment>
+    <rdfs:label xml:lang="en">PCDM File Format Genres</rdfs:label>
+  </owl:Ontology>
+  <udfrs:GenreFacetType rdf:ID="Document">
+    <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
+    <owl:sameAs rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Document" />
+    <owl:sameAs rdf:resource="http://www.udfr.org/onto#DocumentGenre" />
+  </udfrs:GenreFacetType>
+  <udfrs:GenreFacetType rdf:ID="Archive">
+    <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
+    <rdfs:subClassOf rdf:resource="Document" />
+    <owl:sameAs rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Archive" />
+    <owl:sameAs rdf:resource="http://reference.data.gov.uk/technical-registry/Aggregate" />
+    <owl:sameAs rdf:resource="http://www.udfr.org/onto#AggregateGenre" />
+  </udfrs:GenreFacetType>
+  <udfrs:GenreFacetType rdf:ID="Database">
+    <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
+    <rdfs:subClassOf rdf:resource="Document" />
+    <owl:sameAs rdf:resource="http://reference.data.gov.uk/technical-registry/Database" />
+    <owl:sameAs rdf:resource="http://www.udfr.org/onto#DatabaseGenre" />
+  </udfrs:GenreFacetType>
+  <udfrs:GenreFacetType rdf:ID="Dataset">
+    <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
+    <rdfs:subClassOf rdf:resource="Document" />
+    <owl:sameAs rdf:resource="http://reference.data.gov.uk/technical-registry/Dataset" />
+    <owl:sameAs rdf:resource="http://www.udfr.org/onto#DatasetGenre" />
+    <owl:sameAs rdf:resource="http://purl.org/dc/elements/1.1/Dataset" />
+  </udfrs:GenreFacetType>
+  <udfrs:GenreFacetType rdf:ID="Software">
+    <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
+    <rdfs:subClassOf rdf:resource="Document" />
+    <owl:sameAs rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Software" />
+    <owl:sameAs rdf:resource="http://purl.org/dc/elements/1.1/Software" />
+  </udfrs:GenreFacetType>
+  <udfrs:GenreFacetType rdf:ID="Email">
+    <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
+    <rdfs:subClassOf rdf:resource="Document" />
+    <owl:sameAs rdf:resource="http://reference.data.gov.uk/technical-registry/Email" />
+    <owl:sameAs rdf:resource="http://www.udfr.org/onto#EmailGenre" />
+  </udfrs:GenreFacetType>
+  <udfrs:GenreFacetType rdf:ID="Executable">
+    <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
+    <rdfs:subClassOf rdf:resource="Software" />
+    <owl:sameAs rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Executable" />
+    <owl:sameAs rdf:resource="http://www.udfr.org/onto#ExecutableGenre" />
+  </udfrs:GenreFacetType>
+  <udfrs:GenreFacetType rdf:ID="FileHash">
+    <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
+    <rdfs:subClassOf rdf:resource="Document" />
+    <owl:sameAs rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileHash" />
+  </udfrs:GenreFacetType>
+  <udfrs:GenreFacetType rdf:ID="Font">
+    <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
+    <rdfs:subClassOf rdf:resource="Document" />
+    <owl:sameAs rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Font" />
+  </udfrs:GenreFacetType>
+  <udfrs:GenreFacetType rdf:ID="GIS">
+    <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
+    <rdfs:subClassOf rdf:resource="Dataset" />
+    <owl:sameAs rdf:resource="http://reference.data.gov.uk/technical-registry/GIS" />
+  </udfrs:GenreFacetType>
+  <udfrs:GenreFacetType rdf:ID="Model">
+    <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
+    <rdfs:subClassOf rdf:resource="Document" />
+    <owl:sameAs rdf:resource="http://www.udfr.org/onto#ModelGenre" />
+  </udfrs:GenreFacetType>
+  <udfrs:GenreFacetType rdf:ID="Website">
+    <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
+    <rdfs:subClassOf rdf:resource="Document" />
+    <owl:sameAs rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Website" />
+  </udfrs:GenreFacetType>
+  <udfrs:GenreFacetType rdf:ID="Unknown">
+    <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
+    <rdfs:subClassOf rdf:resource="Document" />
+    <owl:sameAs rdf:resource="http://www.udfr.org/onto#Unknown" />
+  </udfrs:GenreFacetType>
+  <!-- All text genres -->
+  <udfrs:GenreFacetType rdf:ID="Text">
+    <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
+    <rdfs:subClassOf rdf:resource="Document" />
+    <owl:sameAs rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#TextDocument" />
+    <owl:sameAs rdf:resource="http://www.udfr.org/onto#TextGenre" />
+    <owl:sameAs rdf:resource="http://purl.org/dc/elements/1.1/Text" />
+  </udfrs:GenreFacetType>
+  <udfrs:GenreFacetType rdf:ID="PageDescription">
+    <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
+    <rdfs:subClassOf rdf:resource="Text" />
+    <owl:sameAs rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#PaginatedTextDocument" />
+    <owl:sameAs rdf:resource="http://reference.data.gov.uk/technical-registry/PageDescription" />
+    <owl:sameAs rdf:resource="http://www.udfr.org/onto#PageDescriptionGenre" />
+  </udfrs:GenreFacetType>
+  <udfrs:GenreFacetType rdf:ID="UnstructuredText">
+    <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
+    <rdfs:subClassOf rdf:resource="Text" />
+    <owl:sameAs rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#PlainTextDocument" />
+    <owl:sameAs rdf:resource="http://reference.data.gov.uk/technical-registry/UnstructuredText" />
+  </udfrs:GenreFacetType>
+  <udfrs:GenreFacetType rdf:ID="StructuredText">
+    <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
+    <rdfs:subClassOf rdf:resource="Text" />
+    <owl:sameAs rdf:resource="http://reference.data.gov.uk/technical-registry/StructuredText" />
+  </udfrs:GenreFacetType>
+  <!-- Structured text genres -->
+  <udfrs:GenreFacetType rdf:ID="SourceCode">
+    <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
+    <rdfs:subClassOf rdf:resource="StructuredText" />
+    <owl:sameAs rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#SourceCode" />
+  </udfrs:GenreFacetType>
+  <udfrs:GenreFacetType rdf:ID="Markup">
+    <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
+    <rdfs:subClassOf rdf:resource="StructuredText" />
+    <owl:sameAs rdf:resource="http://reference.data.gov.uk/technical-registry/MarkupText" />
+  </udfrs:GenreFacetType>
+  <udfrs:GenreFacetType rdf:ID="HTML">
+    <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
+    <rdfs:subClassOf rdf:resource="Markup" />
+    <owl:sameAs rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#HTMLDocument" />
+  </udfrs:GenreFacetType>
+  <udfrs:GenreFacetType rdf:ID="Presentation">
+    <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
+    <rdfs:subClassOf rdf:resource="Document" />
+    <owl:sameAs rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Presentation" />
+    <owl:sameAs rdf:resource="http://reference.data.gov.uk/technical-registry/Presentation" />
+    <owl:sameAs rdf:resource="http://www.udfr.org/onto#PresentationGenre" />
+  </udfrs:GenreFacetType>
+  <udfrs:GenreFacetType rdf:ID="Spreadsheet">
+    <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
+    <rdfs:subClassOf rdf:resource="Document" />
+    <owl:sameAs rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Spreadsheet" />
+    <owl:sameAs rdf:resource="http://reference.data.gov.uk/technical-registry/Spreadsheet" />
+    <owl:sameAs rdf:resource="http://www.udfr.org/onto#SpreadsheetGenre" />
+  </udfrs:GenreFacetType>
+  <!-- All media genres -->
+  <udfrs:GenreFacetType rdf:ID="MediaList">
+    <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
+    <rdfs:subClassOf rdf:resource="Document" />
+    <owl:sameAs rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#MediaList" />
+  </udfrs:GenreFacetType>
+  <udfrs:GenreFacetType rdf:ID="Media">
+    <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
+    <rdfs:subClassOf rdf:resource="Document" />
+    <owl:sameAs rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Media" />
+  </udfrs:GenreFacetType>
+  <udfrs:GenreFacetType rdf:ID="Audio">
+    <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
+    <rdfs:subClassOf rdf:resource="Media" />
+    <owl:sameAs rdf:resource="http://www.udfr.org/onto#SoundGenre" />
+    <owl:sameAs rdf:resource="http://reference.data.gov.uk/technical-registry/Audio" />
+    <owl:sameAs rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Audio" />
+    <owl:sameAs rdf:resource="http://purl.org/dc/elements/1.1/Sound" />
+  </udfrs:GenreFacetType>
+  <udfrs:GenreFacetType rdf:ID="Video">
+    <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
+    <rdfs:subClassOf rdf:resource="Media" />
+    <owl:sameAs rdf:resource="http://www.udfr.org/onto#MovingImageGenre" />
+    <owl:sameAs rdf:resource="http://reference.data.gov.uk/technical-registry/Video" />
+    <owl:sameAs rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Video" />
+    <owl:sameAs rdf:resource="http://purl.org/dc/elements/1.1/MovingImage" />
+  </udfrs:GenreFacetType>
+  <!-- Image genres -->
+  <udfrs:GenreFacetType rdf:ID="Image">
+    <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
+    <rdfs:subClassOf rdf:resource="Media" />
+    <owl:sameAs rdf:resource="http://www.udfr.org/onto#StillImageGenre" />
+    <owl:sameAs rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Image" />
+    <owl:sameAs rdf:resource="http://purl.org/dc/elements/1.1/StillImage" />
+  </udfrs:GenreFacetType>
+  <udfrs:GenreFacetType rdf:ID="RasterImage">
+    <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
+    <rdfs:subClassOf rdf:resource="Image" />
+    <owl:sameAs rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RasterImage" />
+    <owl:sameAs rdf:resource="http://reference.data.gov.uk/technical-registry/RasterImage" />
+  </udfrs:GenreFacetType>
+  <udfrs:GenreFacetType rdf:ID="VectorImage">
+    <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
+    <rdfs:subClassOf rdf:resource="Image" />
+    <owl:sameAs rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#VectorImage" />
+    <owl:sameAs rdf:resource="http://reference.data.gov.uk/technical-registry/VectorImage" />
+  </udfrs:GenreFacetType>
+</rdf:RDF>

--- a/file-format-types.rdf
+++ b/file-format-types.rdf
@@ -11,20 +11,20 @@
   <udfrs:GenreFacetType rdf:ID="Document">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
     <skos:exactMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Document" />
-    <owl:sameAs rdf:resource="http://www.udfr.org/onto#DocumentGenre" />
+    <skos:exactMatch rdf:resource="http://www.udfr.org/onto#DocumentGenre" />
   </udfrs:GenreFacetType>
   <udfrs:GenreFacetType rdf:ID="Archive">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
     <rdfs:subClassOf rdf:resource="Document" />
     <skos:exactMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Archive" />
-    <skos:exactMatch rdf:resource="http://reference.data.gov.uk/technical-registry/Aggregate" />
-    <owl:sameAs rdf:resource="http://www.udfr.org/onto#AggregateGenre" />
+    <skos:closeMatch rdf:resource="http://reference.data.gov.uk/technical-registry/Aggregate" />
+    <skos:closeMatch rdf:resource="http://www.udfr.org/onto#AggregateGenre" />
   </udfrs:GenreFacetType>
   <udfrs:GenreFacetType rdf:ID="Database">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
     <rdfs:subClassOf rdf:resource="Document" />
     <skos:exactMatch rdf:resource="http://reference.data.gov.uk/technical-registry/Database" />
-    <owl:sameAs rdf:resource="http://www.udfr.org/onto#DatabaseGenre" />
+    <skos:exactMatch rdf:resource="http://www.udfr.org/onto#DatabaseGenre" />
   </udfrs:GenreFacetType>
   <udfrs:GenreFacetType rdf:ID="Dataset">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
@@ -43,13 +43,13 @@
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
     <rdfs:subClassOf rdf:resource="Document" />
     <skos:exactMatch rdf:resource="http://reference.data.gov.uk/technical-registry/Email" />
-    <owl:sameAs rdf:resource="http://www.udfr.org/onto#EmailGenre" />
+    <skos:exactMatch rdf:resource="http://www.udfr.org/onto#EmailGenre" />
   </udfrs:GenreFacetType>
   <udfrs:GenreFacetType rdf:ID="Executable">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
     <rdfs:subClassOf rdf:resource="Software" />
     <skos:exactMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Executable" />
-    <owl:sameAs rdf:resource="http://www.udfr.org/onto#ExecutableGenre" />
+    <skos:exactMatch rdf:resource="http://www.udfr.org/onto#ExecutableGenre" />
   </udfrs:GenreFacetType>
   <udfrs:GenreFacetType rdf:ID="FileHash">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
@@ -69,7 +69,7 @@
   <udfrs:GenreFacetType rdf:ID="Model">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
     <rdfs:subClassOf rdf:resource="Document" />
-    <owl:sameAs rdf:resource="http://www.udfr.org/onto#ModelGenre" />
+    <skos:exactMatch rdf:resource="http://www.udfr.org/onto#ModelGenre" />
   </udfrs:GenreFacetType>
   <udfrs:GenreFacetType rdf:ID="Website">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
@@ -79,14 +79,14 @@
   <udfrs:GenreFacetType rdf:ID="Unknown">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
     <rdfs:subClassOf rdf:resource="Document" />
-    <owl:sameAs rdf:resource="http://www.udfr.org/onto#Unknown" />
+    <skos:exactMatch rdf:resource="http://www.udfr.org/onto#Unknown" />
   </udfrs:GenreFacetType>
   <!-- All text genres -->
   <udfrs:GenreFacetType rdf:ID="Text">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
     <rdfs:subClassOf rdf:resource="Document" />
     <skos:exactMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#TextDocument" />
-    <owl:sameAs rdf:resource="http://www.udfr.org/onto#TextGenre" />
+    <skos:exactMatch rdf:resource="http://www.udfr.org/onto#TextGenre" />
     <skos:exactMatch rdf:resource="http://purl.org/dc/elements/1.1/Text" />
   </udfrs:GenreFacetType>
   <udfrs:GenreFacetType rdf:ID="PageDescription">
@@ -94,7 +94,7 @@
     <rdfs:subClassOf rdf:resource="Text" />
     <skos:exactMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#PaginatedTextDocument" />
     <skos:exactMatch rdf:resource="http://reference.data.gov.uk/technical-registry/PageDescription" />
-    <owl:sameAs rdf:resource="http://www.udfr.org/onto#PageDescriptionGenre" />
+    <skos:exactMatch rdf:resource="http://www.udfr.org/onto#PageDescriptionGenre" />
   </udfrs:GenreFacetType>
   <udfrs:GenreFacetType rdf:ID="UnstructuredText">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
@@ -128,14 +128,14 @@
     <rdfs:subClassOf rdf:resource="Document" />
     <skos:exactMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Presentation" />
     <skos:exactMatch rdf:resource="http://reference.data.gov.uk/technical-registry/Presentation" />
-    <owl:sameAs rdf:resource="http://www.udfr.org/onto#PresentationGenre" />
+    <skos:exactMatch rdf:resource="http://www.udfr.org/onto#PresentationGenre" />
   </udfrs:GenreFacetType>
   <udfrs:GenreFacetType rdf:ID="Spreadsheet">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
     <rdfs:subClassOf rdf:resource="Document" />
     <skos:exactMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Spreadsheet" />
     <skos:exactMatch rdf:resource="http://reference.data.gov.uk/technical-registry/Spreadsheet" />
-    <owl:sameAs rdf:resource="http://www.udfr.org/onto#SpreadsheetGenre" />
+    <skos:exactMatch rdf:resource="http://www.udfr.org/onto#SpreadsheetGenre" />
   </udfrs:GenreFacetType>
   <!-- All media genres -->
   <udfrs:GenreFacetType rdf:ID="MediaList">
@@ -151,7 +151,7 @@
   <udfrs:GenreFacetType rdf:ID="Audio">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
     <rdfs:subClassOf rdf:resource="Media" />
-    <owl:sameAs rdf:resource="http://www.udfr.org/onto#SoundGenre" />
+    <skos:exactMatch rdf:resource="http://www.udfr.org/onto#SoundGenre" />
     <skos:exactMatch rdf:resource="http://reference.data.gov.uk/technical-registry/Audio" />
     <skos:exactMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Audio" />
     <skos:exactMatch rdf:resource="http://purl.org/dc/elements/1.1/Sound" />
@@ -159,7 +159,7 @@
   <udfrs:GenreFacetType rdf:ID="Video">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
     <rdfs:subClassOf rdf:resource="Media" />
-    <owl:sameAs rdf:resource="http://www.udfr.org/onto#MovingImageGenre" />
+    <skos:exactMatch rdf:resource="http://www.udfr.org/onto#MovingImageGenre" />
     <skos:exactMatch rdf:resource="http://reference.data.gov.uk/technical-registry/Video" />
     <skos:exactMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Video" />
     <skos:exactMatch rdf:resource="http://purl.org/dc/elements/1.1/MovingImage" />
@@ -168,7 +168,7 @@
   <udfrs:GenreFacetType rdf:ID="Image">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
     <rdfs:subClassOf rdf:resource="Media" />
-    <owl:sameAs rdf:resource="http://www.udfr.org/onto#StillImageGenre" />
+    <skos:exactMatch rdf:resource="http://www.udfr.org/onto#StillImageGenre" />
     <skos:exactMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Image" />
     <skos:exactMatch rdf:resource="http://purl.org/dc/elements/1.1/StillImage" />
   </udfrs:GenreFacetType>

--- a/file-format-types.rdf
+++ b/file-format-types.rdf
@@ -10,12 +10,14 @@
   </owl:Ontology>
   <udfrs:GenreFacetType rdf:ID="Document">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
+    <skos:exactMatch rdf:resource="http://vocab.getty.edu/aat/300026031" />
     <skos:exactMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Document" />
     <skos:exactMatch rdf:resource="http://www.udfr.org/onto#DocumentGenre" />
   </udfrs:GenreFacetType>
   <udfrs:GenreFacetType rdf:ID="Archive">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
     <rdfs:subClassOf rdf:resource="Document" />
+    <skos:exactMatch rdf:resource="http://vocab.getty.edu/aat/300375748" />
     <skos:exactMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Archive" />
     <skos:closeMatch rdf:resource="http://reference.data.gov.uk/technical-registry/Aggregate" />
     <skos:closeMatch rdf:resource="http://www.udfr.org/onto#AggregateGenre" />
@@ -23,6 +25,7 @@
   <udfrs:GenreFacetType rdf:ID="Database">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
     <rdfs:subClassOf rdf:resource="Document" />
+    <skos:exactMatch rdf:resource="http://vocab.getty.edu/aat/300028543" />
     <skos:exactMatch rdf:resource="http://reference.data.gov.uk/technical-registry/Database" />
     <skos:exactMatch rdf:resource="http://www.udfr.org/onto#DatabaseGenre" />
   </udfrs:GenreFacetType>
@@ -32,16 +35,19 @@
     <skos:exactMatch rdf:resource="http://reference.data.gov.uk/technical-registry/Dataset" />
     <skos:exactMatch rdf:resource="http://www.udfr.org/onto#DatasetGenre" />
     <skos:exactMatch rdf:resource="http://purl.org/dc/elements/1.1/Dataset" />
+    <skos:exactMatch rdf:resource="http://id.loc.gov/vocabulary/resourceTypes/Dat" />
   </udfrs:GenreFacetType>
   <udfrs:GenreFacetType rdf:ID="Software">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
     <rdfs:subClassOf rdf:resource="Document" />
     <skos:exactMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Software" />
     <skos:exactMatch rdf:resource="http://purl.org/dc/elements/1.1/Software" />
+    <skos:exactMatch rdf:resource="http://vocab.getty.edu/aat/300028566" />
   </udfrs:GenreFacetType>
   <udfrs:GenreFacetType rdf:ID="Email">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
     <rdfs:subClassOf rdf:resource="Document" />
+    <skos:exactMatch rdf:resource="http://vocab.getty.edu/aat/300149026" />
     <skos:exactMatch rdf:resource="http://reference.data.gov.uk/technical-registry/Email" />
     <skos:exactMatch rdf:resource="http://www.udfr.org/onto#EmailGenre" />
   </udfrs:GenreFacetType>
@@ -70,16 +76,19 @@
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
     <rdfs:subClassOf rdf:resource="Document" />
     <skos:exactMatch rdf:resource="http://www.udfr.org/onto#ModelGenre" />
+    <skos:exactMatch rdf:resource="http://vocab.getty.edu/aat/300047753" />
   </udfrs:GenreFacetType>
   <udfrs:GenreFacetType rdf:ID="Website">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
     <rdfs:subClassOf rdf:resource="Document" />
     <skos:exactMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Website" />
+    <skos:exactMatch rdf:resource="http://vocab.getty.edu/aat/300265431" />
   </udfrs:GenreFacetType>
   <udfrs:GenreFacetType rdf:ID="Unknown">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
     <rdfs:subClassOf rdf:resource="Document" />
     <skos:exactMatch rdf:resource="http://www.udfr.org/onto#Unknown" />
+    <skos:exactMatch rdf:resource="http://id.loc.gov/vocabulary/resourceTypes/Unk" />
   </udfrs:GenreFacetType>
   <!-- All text genres -->
   <udfrs:GenreFacetType rdf:ID="Text">
@@ -88,6 +97,7 @@
     <skos:exactMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#TextDocument" />
     <skos:exactMatch rdf:resource="http://www.udfr.org/onto#TextGenre" />
     <skos:exactMatch rdf:resource="http://purl.org/dc/elements/1.1/Text" />
+    <skos:exactMatch rdf:resource="http://id.loc.gov/vocabulary/resourceTypes/Txt" />
   </udfrs:GenreFacetType>
   <udfrs:GenreFacetType rdf:ID="PageDescription">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
@@ -122,6 +132,7 @@
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
     <rdfs:subClassOf rdf:resource="Markup" />
     <skos:exactMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#HTMLDocument" />
+    <skos:exactMatch rdf:resource="http://vocab.getty.edu/aat/300266021" />
   </udfrs:GenreFacetType>
   <udfrs:GenreFacetType rdf:ID="Presentation">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
@@ -147,6 +158,7 @@
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
     <rdfs:subClassOf rdf:resource="Document" />
     <skos:exactMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Media" />
+    <skos:exactMatch rdf:resource="http://id.loc.gov/vocabulary/resourceTypes/Mul" />
   </udfrs:GenreFacetType>
   <udfrs:GenreFacetType rdf:ID="Audio">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
@@ -155,6 +167,7 @@
     <skos:exactMatch rdf:resource="http://reference.data.gov.uk/technical-registry/Audio" />
     <skos:exactMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Audio" />
     <skos:exactMatch rdf:resource="http://purl.org/dc/elements/1.1/Sound" />
+    <skos:exactMatch rdf:resource="http://id.loc.gov/vocabulary/resourceTypes/Aud" />
   </udfrs:GenreFacetType>
   <udfrs:GenreFacetType rdf:ID="Video">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
@@ -163,6 +176,7 @@
     <skos:exactMatch rdf:resource="http://reference.data.gov.uk/technical-registry/Video" />
     <skos:exactMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Video" />
     <skos:exactMatch rdf:resource="http://purl.org/dc/elements/1.1/MovingImage" />
+    <skos:exactMatch rdf:resource="http://id.loc.gov/vocabulary/resourceTypes/Mov" />
   </udfrs:GenreFacetType>
   <!-- Image genres -->
   <udfrs:GenreFacetType rdf:ID="Image">
@@ -171,6 +185,7 @@
     <skos:exactMatch rdf:resource="http://www.udfr.org/onto#StillImageGenre" />
     <skos:exactMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Image" />
     <skos:exactMatch rdf:resource="http://purl.org/dc/elements/1.1/StillImage" />
+    <skos:exactMatch rdf:resource="http://id.loc.gov/vocabulary/resourceTypes/Img" />
   </udfrs:GenreFacetType>
   <udfrs:GenreFacetType rdf:ID="RasterImage">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>

--- a/file-format-types.rdf
+++ b/file-format-types.rdf
@@ -2,6 +2,7 @@
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
   xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
   xmlns:owl="http://www.w3.org/2002/07/owl#"
+  xmlns:skos="http://www.w3.org/2004/02/skos/core#"
   xmlns:udfrs="http://www.udfr.org/onto#">
   <owl:Ontology rdf:about="http://pcdm.org/file-format-types#">
     <rdfs:comment xml:lang="en">PCDM File Format Genre ontology.</rdfs:comment>
@@ -9,61 +10,61 @@
   </owl:Ontology>
   <udfrs:GenreFacetType rdf:ID="Document">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
-    <owl:sameAs rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Document" />
+    <skos:exactMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Document" />
     <owl:sameAs rdf:resource="http://www.udfr.org/onto#DocumentGenre" />
   </udfrs:GenreFacetType>
   <udfrs:GenreFacetType rdf:ID="Archive">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
     <rdfs:subClassOf rdf:resource="Document" />
-    <owl:sameAs rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Archive" />
-    <owl:sameAs rdf:resource="http://reference.data.gov.uk/technical-registry/Aggregate" />
+    <skos:exactMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Archive" />
+    <skos:exactMatch rdf:resource="http://reference.data.gov.uk/technical-registry/Aggregate" />
     <owl:sameAs rdf:resource="http://www.udfr.org/onto#AggregateGenre" />
   </udfrs:GenreFacetType>
   <udfrs:GenreFacetType rdf:ID="Database">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
     <rdfs:subClassOf rdf:resource="Document" />
-    <owl:sameAs rdf:resource="http://reference.data.gov.uk/technical-registry/Database" />
+    <skos:exactMatch rdf:resource="http://reference.data.gov.uk/technical-registry/Database" />
     <owl:sameAs rdf:resource="http://www.udfr.org/onto#DatabaseGenre" />
   </udfrs:GenreFacetType>
   <udfrs:GenreFacetType rdf:ID="Dataset">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
     <rdfs:subClassOf rdf:resource="Document" />
-    <owl:sameAs rdf:resource="http://reference.data.gov.uk/technical-registry/Dataset" />
-    <owl:sameAs rdf:resource="http://www.udfr.org/onto#DatasetGenre" />
-    <owl:sameAs rdf:resource="http://purl.org/dc/elements/1.1/Dataset" />
+    <skos:exactMatch rdf:resource="http://reference.data.gov.uk/technical-registry/Dataset" />
+    <skos:exactMatch rdf:resource="http://www.udfr.org/onto#DatasetGenre" />
+    <skos:exactMatch rdf:resource="http://purl.org/dc/elements/1.1/Dataset" />
   </udfrs:GenreFacetType>
   <udfrs:GenreFacetType rdf:ID="Software">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
     <rdfs:subClassOf rdf:resource="Document" />
-    <owl:sameAs rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Software" />
-    <owl:sameAs rdf:resource="http://purl.org/dc/elements/1.1/Software" />
+    <skos:exactMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Software" />
+    <skos:exactMatch rdf:resource="http://purl.org/dc/elements/1.1/Software" />
   </udfrs:GenreFacetType>
   <udfrs:GenreFacetType rdf:ID="Email">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
     <rdfs:subClassOf rdf:resource="Document" />
-    <owl:sameAs rdf:resource="http://reference.data.gov.uk/technical-registry/Email" />
+    <skos:exactMatch rdf:resource="http://reference.data.gov.uk/technical-registry/Email" />
     <owl:sameAs rdf:resource="http://www.udfr.org/onto#EmailGenre" />
   </udfrs:GenreFacetType>
   <udfrs:GenreFacetType rdf:ID="Executable">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
     <rdfs:subClassOf rdf:resource="Software" />
-    <owl:sameAs rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Executable" />
+    <skos:exactMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Executable" />
     <owl:sameAs rdf:resource="http://www.udfr.org/onto#ExecutableGenre" />
   </udfrs:GenreFacetType>
   <udfrs:GenreFacetType rdf:ID="FileHash">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
     <rdfs:subClassOf rdf:resource="Document" />
-    <owl:sameAs rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileHash" />
+    <skos:exactMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileHash" />
   </udfrs:GenreFacetType>
   <udfrs:GenreFacetType rdf:ID="Font">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
     <rdfs:subClassOf rdf:resource="Document" />
-    <owl:sameAs rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Font" />
+    <skos:exactMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Font" />
   </udfrs:GenreFacetType>
   <udfrs:GenreFacetType rdf:ID="GIS">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
     <rdfs:subClassOf rdf:resource="Dataset" />
-    <owl:sameAs rdf:resource="http://reference.data.gov.uk/technical-registry/GIS" />
+    <skos:exactMatch rdf:resource="http://reference.data.gov.uk/technical-registry/GIS" />
   </udfrs:GenreFacetType>
   <udfrs:GenreFacetType rdf:ID="Model">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
@@ -73,7 +74,7 @@
   <udfrs:GenreFacetType rdf:ID="Website">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
     <rdfs:subClassOf rdf:resource="Document" />
-    <owl:sameAs rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Website" />
+    <skos:exactMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Website" />
   </udfrs:GenreFacetType>
   <udfrs:GenreFacetType rdf:ID="Unknown">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
@@ -84,103 +85,103 @@
   <udfrs:GenreFacetType rdf:ID="Text">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
     <rdfs:subClassOf rdf:resource="Document" />
-    <owl:sameAs rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#TextDocument" />
+    <skos:exactMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#TextDocument" />
     <owl:sameAs rdf:resource="http://www.udfr.org/onto#TextGenre" />
-    <owl:sameAs rdf:resource="http://purl.org/dc/elements/1.1/Text" />
+    <skos:exactMatch rdf:resource="http://purl.org/dc/elements/1.1/Text" />
   </udfrs:GenreFacetType>
   <udfrs:GenreFacetType rdf:ID="PageDescription">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
     <rdfs:subClassOf rdf:resource="Text" />
-    <owl:sameAs rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#PaginatedTextDocument" />
-    <owl:sameAs rdf:resource="http://reference.data.gov.uk/technical-registry/PageDescription" />
+    <skos:exactMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#PaginatedTextDocument" />
+    <skos:exactMatch rdf:resource="http://reference.data.gov.uk/technical-registry/PageDescription" />
     <owl:sameAs rdf:resource="http://www.udfr.org/onto#PageDescriptionGenre" />
   </udfrs:GenreFacetType>
   <udfrs:GenreFacetType rdf:ID="UnstructuredText">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
     <rdfs:subClassOf rdf:resource="Text" />
-    <owl:sameAs rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#PlainTextDocument" />
-    <owl:sameAs rdf:resource="http://reference.data.gov.uk/technical-registry/UnstructuredText" />
+    <skos:closeMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#PlainTextDocument" />
+    <skos:exactMatch rdf:resource="http://reference.data.gov.uk/technical-registry/UnstructuredText" />
   </udfrs:GenreFacetType>
   <udfrs:GenreFacetType rdf:ID="StructuredText">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
     <rdfs:subClassOf rdf:resource="Text" />
-    <owl:sameAs rdf:resource="http://reference.data.gov.uk/technical-registry/StructuredText" />
+    <skos:exactMatch rdf:resource="http://reference.data.gov.uk/technical-registry/StructuredText" />
   </udfrs:GenreFacetType>
   <!-- Structured text genres -->
   <udfrs:GenreFacetType rdf:ID="SourceCode">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
     <rdfs:subClassOf rdf:resource="StructuredText" />
-    <owl:sameAs rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#SourceCode" />
+    <skos:exactMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#SourceCode" />
   </udfrs:GenreFacetType>
   <udfrs:GenreFacetType rdf:ID="Markup">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
     <rdfs:subClassOf rdf:resource="StructuredText" />
-    <owl:sameAs rdf:resource="http://reference.data.gov.uk/technical-registry/MarkupText" />
+    <skos:exactMatch rdf:resource="http://reference.data.gov.uk/technical-registry/MarkupText" />
   </udfrs:GenreFacetType>
   <udfrs:GenreFacetType rdf:ID="HTML">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
     <rdfs:subClassOf rdf:resource="Markup" />
-    <owl:sameAs rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#HTMLDocument" />
+    <skos:exactMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#HTMLDocument" />
   </udfrs:GenreFacetType>
   <udfrs:GenreFacetType rdf:ID="Presentation">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
     <rdfs:subClassOf rdf:resource="Document" />
-    <owl:sameAs rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Presentation" />
-    <owl:sameAs rdf:resource="http://reference.data.gov.uk/technical-registry/Presentation" />
+    <skos:exactMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Presentation" />
+    <skos:exactMatch rdf:resource="http://reference.data.gov.uk/technical-registry/Presentation" />
     <owl:sameAs rdf:resource="http://www.udfr.org/onto#PresentationGenre" />
   </udfrs:GenreFacetType>
   <udfrs:GenreFacetType rdf:ID="Spreadsheet">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
     <rdfs:subClassOf rdf:resource="Document" />
-    <owl:sameAs rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Spreadsheet" />
-    <owl:sameAs rdf:resource="http://reference.data.gov.uk/technical-registry/Spreadsheet" />
+    <skos:exactMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Spreadsheet" />
+    <skos:exactMatch rdf:resource="http://reference.data.gov.uk/technical-registry/Spreadsheet" />
     <owl:sameAs rdf:resource="http://www.udfr.org/onto#SpreadsheetGenre" />
   </udfrs:GenreFacetType>
   <!-- All media genres -->
   <udfrs:GenreFacetType rdf:ID="MediaList">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
     <rdfs:subClassOf rdf:resource="Document" />
-    <owl:sameAs rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#MediaList" />
+    <skos:exactMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#MediaList" />
   </udfrs:GenreFacetType>
   <udfrs:GenreFacetType rdf:ID="Media">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
     <rdfs:subClassOf rdf:resource="Document" />
-    <owl:sameAs rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Media" />
+    <skos:exactMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Media" />
   </udfrs:GenreFacetType>
   <udfrs:GenreFacetType rdf:ID="Audio">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
     <rdfs:subClassOf rdf:resource="Media" />
     <owl:sameAs rdf:resource="http://www.udfr.org/onto#SoundGenre" />
-    <owl:sameAs rdf:resource="http://reference.data.gov.uk/technical-registry/Audio" />
-    <owl:sameAs rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Audio" />
-    <owl:sameAs rdf:resource="http://purl.org/dc/elements/1.1/Sound" />
+    <skos:exactMatch rdf:resource="http://reference.data.gov.uk/technical-registry/Audio" />
+    <skos:exactMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Audio" />
+    <skos:exactMatch rdf:resource="http://purl.org/dc/elements/1.1/Sound" />
   </udfrs:GenreFacetType>
   <udfrs:GenreFacetType rdf:ID="Video">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
     <rdfs:subClassOf rdf:resource="Media" />
     <owl:sameAs rdf:resource="http://www.udfr.org/onto#MovingImageGenre" />
-    <owl:sameAs rdf:resource="http://reference.data.gov.uk/technical-registry/Video" />
-    <owl:sameAs rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Video" />
-    <owl:sameAs rdf:resource="http://purl.org/dc/elements/1.1/MovingImage" />
+    <skos:exactMatch rdf:resource="http://reference.data.gov.uk/technical-registry/Video" />
+    <skos:exactMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Video" />
+    <skos:exactMatch rdf:resource="http://purl.org/dc/elements/1.1/MovingImage" />
   </udfrs:GenreFacetType>
   <!-- Image genres -->
   <udfrs:GenreFacetType rdf:ID="Image">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
     <rdfs:subClassOf rdf:resource="Media" />
     <owl:sameAs rdf:resource="http://www.udfr.org/onto#StillImageGenre" />
-    <owl:sameAs rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Image" />
-    <owl:sameAs rdf:resource="http://purl.org/dc/elements/1.1/StillImage" />
+    <skos:exactMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Image" />
+    <skos:exactMatch rdf:resource="http://purl.org/dc/elements/1.1/StillImage" />
   </udfrs:GenreFacetType>
   <udfrs:GenreFacetType rdf:ID="RasterImage">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
     <rdfs:subClassOf rdf:resource="Image" />
-    <owl:sameAs rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RasterImage" />
-    <owl:sameAs rdf:resource="http://reference.data.gov.uk/technical-registry/RasterImage" />
+    <skos:exactMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RasterImage" />
+    <skos:exactMatch rdf:resource="http://reference.data.gov.uk/technical-registry/RasterImage" />
   </udfrs:GenreFacetType>
   <udfrs:GenreFacetType rdf:ID="VectorImage">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
     <rdfs:subClassOf rdf:resource="Image" />
-    <owl:sameAs rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#VectorImage" />
-    <owl:sameAs rdf:resource="http://reference.data.gov.uk/technical-registry/VectorImage" />
+    <skos:exactMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#VectorImage" />
+    <skos:exactMatch rdf:resource="http://reference.data.gov.uk/technical-registry/VectorImage" />
   </udfrs:GenreFacetType>
 </rdf:RDF>

--- a/file-format-types.rdf
+++ b/file-format-types.rdf
@@ -34,15 +34,15 @@
     <rdfs:subClassOf rdf:resource="Document" />
     <skos:exactMatch rdf:resource="http://reference.data.gov.uk/technical-registry/Dataset" />
     <skos:exactMatch rdf:resource="http://www.udfr.org/onto#DatasetGenre" />
-    <skos:exactMatch rdf:resource="http://purl.org/dc/elements/1.1/Dataset" />
     <skos:exactMatch rdf:resource="http://id.loc.gov/vocabulary/resourceTypes/Dat" />
+    <skos:exactMatch rdf:resource="http://purl.org/dc/dcmitype/Dataset" />
   </udfrs:GenreFacetType>
   <udfrs:GenreFacetType rdf:ID="Software">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
     <rdfs:subClassOf rdf:resource="Document" />
     <skos:exactMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Software" />
-    <skos:exactMatch rdf:resource="http://purl.org/dc/elements/1.1/Software" />
     <skos:exactMatch rdf:resource="http://vocab.getty.edu/aat/300028566" />
+    <skos:exactMatch rdf:resource="http://purl.org/dc/dcmitype/Software" />
   </udfrs:GenreFacetType>
   <udfrs:GenreFacetType rdf:ID="Email">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
@@ -96,7 +96,7 @@
     <rdfs:subClassOf rdf:resource="Document" />
     <skos:exactMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#TextDocument" />
     <skos:exactMatch rdf:resource="http://www.udfr.org/onto#TextGenre" />
-    <skos:exactMatch rdf:resource="http://purl.org/dc/elements/1.1/Text" />
+    <skos:exactMatch rdf:resource="http://purl.org/dc/dcmitype/Text" />
     <skos:exactMatch rdf:resource="http://id.loc.gov/vocabulary/resourceTypes/Txt" />
   </udfrs:GenreFacetType>
   <udfrs:GenreFacetType rdf:ID="PageDescription">
@@ -166,8 +166,8 @@
     <skos:exactMatch rdf:resource="http://www.udfr.org/onto#SoundGenre" />
     <skos:exactMatch rdf:resource="http://reference.data.gov.uk/technical-registry/Audio" />
     <skos:exactMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Audio" />
-    <skos:exactMatch rdf:resource="http://purl.org/dc/elements/1.1/Sound" />
     <skos:exactMatch rdf:resource="http://id.loc.gov/vocabulary/resourceTypes/Aud" />
+    <skos:exactMatch rdf:resource="http://purl.org/dc/dcmitype/Sound" />
   </udfrs:GenreFacetType>
   <udfrs:GenreFacetType rdf:ID="Video">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
@@ -175,8 +175,8 @@
     <skos:exactMatch rdf:resource="http://www.udfr.org/onto#MovingImageGenre" />
     <skos:exactMatch rdf:resource="http://reference.data.gov.uk/technical-registry/Video" />
     <skos:exactMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Video" />
-    <skos:exactMatch rdf:resource="http://purl.org/dc/elements/1.1/MovingImage" />
     <skos:exactMatch rdf:resource="http://id.loc.gov/vocabulary/resourceTypes/Mov" />
+    <skos:exactMatch rdf:resource="http://purl.org/dc/dcmitype/MovingImage" />
   </udfrs:GenreFacetType>
   <!-- Image genres -->
   <udfrs:GenreFacetType rdf:ID="Image">
@@ -184,8 +184,8 @@
     <rdfs:subClassOf rdf:resource="Media" />
     <skos:exactMatch rdf:resource="http://www.udfr.org/onto#StillImageGenre" />
     <skos:exactMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Image" />
-    <skos:exactMatch rdf:resource="http://purl.org/dc/elements/1.1/StillImage" />
     <skos:exactMatch rdf:resource="http://id.loc.gov/vocabulary/resourceTypes/Img" />
+    <skos:exactMatch rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
   </udfrs:GenreFacetType>
   <udfrs:GenreFacetType rdf:ID="RasterImage">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>

--- a/pcdm-ext/README.md
+++ b/pcdm-ext/README.md
@@ -1,0 +1,4 @@
+# PCDM Extension Ontologies
+
+Optional/extension ontologies for use with PCDM.  This is a place for collecting
+vocabularies that are related to PCDM but not part of the core PCDM models.

--- a/pcdm-ext/file-format-types.rdf
+++ b/pcdm-ext/file-format-types.rdf
@@ -12,7 +12,7 @@
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
     <skos:exactMatch rdf:resource="http://vocab.getty.edu/aat/300026031" />
     <skos:exactMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Document" />
-    <skos:exactMatch rdf:resource="http://www.udfr.org/onto#DocumentGenre" />
+    <skos:narrowMatch rdf:resource="http://www.udfr.org/onto#DocumentGenre" />
   </udfrs:GenreFacetType>
   <udfrs:GenreFacetType rdf:ID="Archive">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
@@ -134,19 +134,32 @@
     <skos:exactMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#HTMLDocument" />
     <skos:exactMatch rdf:resource="http://vocab.getty.edu/aat/300266021" />
   </udfrs:GenreFacetType>
-  <udfrs:GenreFacetType rdf:ID="Presentation">
+  <!-- All office/productivity types -->
+  <udfrs:GenreFacetType rdf:ID="OfficeDocument">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
     <rdfs:subClassOf rdf:resource="Document" />
+    <rdfs:subClassOf rdf:resource="Text" />
+  </udfrs:GenreFacetType>
+  <udfrs:GenreFacetType rdf:ID="Presentation">
+    <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
+    <rdfs:subClassOf rdf:resource="OfficeDocument" />
     <skos:exactMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Presentation" />
     <skos:exactMatch rdf:resource="http://reference.data.gov.uk/technical-registry/Presentation" />
     <skos:exactMatch rdf:resource="http://www.udfr.org/onto#PresentationGenre" />
   </udfrs:GenreFacetType>
   <udfrs:GenreFacetType rdf:ID="Spreadsheet">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
-    <rdfs:subClassOf rdf:resource="Document" />
+    <rdfs:subClassOf rdf:resource="OfficeDocument" />
     <skos:exactMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Spreadsheet" />
     <skos:exactMatch rdf:resource="http://reference.data.gov.uk/technical-registry/Spreadsheet" />
     <skos:exactMatch rdf:resource="http://www.udfr.org/onto#SpreadsheetGenre" />
+  </udfrs:GenreFacetType>
+  <udfrs:GenreFacetType rdf:ID="WordProcessingDocument">
+    <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
+    <rdfs:subClassOf rdf:resource="OfficeDocument" />
+    <skos:closeMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#PaginatedTextDocument" />
+    <skos:exactMatch rdf:resource="http://reference.data.gov.uk/technical-registry/WordprocessedText" />
+    <skos:exactMatch rdf:resource="http://www.udfr.org/onto#DocumentGenre" />
   </udfrs:GenreFacetType>
   <!-- All media genres -->
   <udfrs:GenreFacetType rdf:ID="MediaList">

--- a/pcdm-ext/use.rdf
+++ b/pcdm-ext/use.rdf
@@ -1,0 +1,76 @@
+<?xml version="1.0"?>
+<rdf:RDF
+    xmlns:dcterms="http://purl.org/dc/terms/"
+    xmlns:owl="http://www.w3.org/2002/07/owl#"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+
+  <rdf:Description rdf:about="http://pcdm.org/use#">
+    <dcterms:title xml:lang="en">Portland Common Data Model: Use Extension</dcterms:title>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2015-05-12</dcterms:modified>
+    <dcterms:publisher rdf:resource="http://www.duraspace.org/"/>
+    <rdfs:seeAlso rdf:resource="https://wiki.duraspace.org/display/FF/Portland+Common+Data+Model"/>
+    <rdfs:seeAlso rdf:resource="https://wiki.duraspace.org/display/hydra/File+Use+Vocabulary"/>
+    <rdfs:comment xml:lang="en">Ontology for a PCDM extension to add subclasses of PCDM File for the
+        different roles files have in relation to the Object they are attached to.</rdfs:comment>
+    <owl:versionInfo>2015/05/12</owl:versionInfo>
+  </rdf:Description>
+
+  <rdfs:Class rdf:about="http://pcdm.org/use#ExtractedText">
+    <rdfs:label xml:lang="en">extracted text</rdfs:label>
+    <rdfs:comment xml:lang="en">A textual representation of the Object appropriate for fulltext indexing,
+        such as a plaintext version of a document, or OCR text.</rdfs:comment>
+    <rdf:subClassOf rdf:resource="http://pcdm.org/models#File"/>
+    <rdfs:isDefinedBy rdf:resource="http://pcdm.org/use#"/>
+  </rdfs:Class>
+
+  <rdfs:Class rdf:about="http://pcdm.org/use#IntermediateFile">
+    <rdfs:label xml:lang="en">intermediate file</rdfs:label>
+    <rdfs:comment xml:lang="en">High quality representation of the Object, appropriate for generating
+        derivatives or other additional processing.</rdfs:comment>
+    <rdf:subClassOf rdf:resource="http://pcdm.org/models#File"/>
+    <rdfs:isDefinedBy rdf:resource="http://pcdm.org/use#"/>
+  </rdfs:Class>
+
+  <rdfs:Class rdf:about="http://pcdm.org/use#OriginalFile">
+    <rdfs:label xml:lang="en">original file</rdfs:label>
+    <rdfs:comment xml:lang="en">The original creation format of a file.</rdfs:comment>
+    <rdf:subClassOf rdf:resource="http://pcdm.org/models#File"/>
+    <rdfs:isDefinedBy rdf:resource="http://pcdm.org/use#"/>
+  </rdfs:Class>
+
+  <rdfs:Class rdf:about="http://pcdm.org/use#PreservationMasterFile">
+    <rdfs:label xml:lang="en">preservation master file</rdfs:label>
+    <rdfs:comment xml:lang="en">Best quality representation of the Object appropriate for long-term
+        preservation.</rdfs:comment>
+    <rdf:subClassOf rdf:resource="http://pcdm.org/models#File"/>
+    <rdfs:isDefinedBy rdf:resource="http://pcdm.org/use#"/>
+  </rdfs:Class>
+
+  <rdfs:Class rdf:about="http://pcdm.org/use#ServiceFile">
+    <rdfs:label xml:lang="en">service file</rdfs:label>
+    <rdfs:comment xml:lang="en">A medium quality representation of the Object appropriate for serving to
+        users.  Similar to a FADGI "derivative file" but can also be used for born-digital content,
+        and is not necessarily derived from another file.</rdfs:comment>
+    <rdf:subClassOf rdf:resource="http://pcdm.org/models#File"/>
+    <rdfs:isDefinedBy rdf:resource="http://pcdm.org/use#"/>
+  </rdfs:Class>
+
+  <rdfs:Class rdf:about="http://pcdm.org/use#ThumbnailImage">
+    <rdfs:label xml:lang="en">thumbnail image</rdfs:label>
+    <rdfs:comment xml:lang="en">A low resolution image representation of the Object appropriate for using
+        as an icon.</rdfs:comment>
+    <rdf:subClassOf rdf:resource="http://pcdm.org/models#File"/>
+    <rdfs:isDefinedBy rdf:resource="http://pcdm.org/use#"/>
+  </rdfs:Class>
+
+  <rdfs:Class rdf:about="http://pcdm.org/use#Transcript">
+    <rdfs:label xml:lang="en">transcript</rdfs:label>
+    <rdfs:comment xml:lang="en">A textual representation of the Object appropriate for presenting to users,
+        such as subtitles or transcript of a video.  Can be used as a substitute or complement to other
+        files for accessibility purposes.</rdfs:comment>
+    <rdf:subClassOf rdf:resource="http://pcdm.org/models#ExtractedText"/>
+    <rdfs:isDefinedBy rdf:resource="http://pcdm.org/use#"/>
+  </rdfs:Class>
+
+</rdf:RDF>


### PR DESCRIPTION
- Rebasing on duraspace/pcdm master
- Moving file-format-types.rdf to pcdm-ext
- Adding OfficeDocument and WordProcessingDocument types, making Presentation and Spreadsheet children of OfficeDocument
