### PR TITLE
Adding OfficeDocument as a superclass of Presentation, Spreadsheet, and WordProcessingDocument

### DIFF
--- a/pcdm-ext/file-format-types.rdf
+++ b/pcdm-ext/file-format-types.rdf
@@ -134,23 +134,29 @@
     <skos:exactMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#HTMLDocument" />
     <skos:exactMatch rdf:resource="http://vocab.getty.edu/aat/300266021" />
   </udfrs:GenreFacetType>
-  <udfrs:GenreFacetType rdf:ID="Presentation">
+  <!-- All office/productivity types -->
+  <udfrs:GenreFacetType rdf:ID="OfficeDocument">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
     <rdfs:subClassOf rdf:resource="Document" />
+    <rdfs:subClassOf rdf:resource="Text" />
+  </udfrs:GenreFacetType>
+  <udfrs:GenreFacetType rdf:ID="Presentation">
+    <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
+    <rdfs:subClassOf rdf:resource="OfficeDocument" />
     <skos:exactMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Presentation" />
     <skos:exactMatch rdf:resource="http://reference.data.gov.uk/technical-registry/Presentation" />
     <skos:exactMatch rdf:resource="http://www.udfr.org/onto#PresentationGenre" />
   </udfrs:GenreFacetType>
   <udfrs:GenreFacetType rdf:ID="Spreadsheet">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
-    <rdfs:subClassOf rdf:resource="Document" />
+    <rdfs:subClassOf rdf:resource="OfficeDocument" />
     <skos:exactMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Spreadsheet" />
     <skos:exactMatch rdf:resource="http://reference.data.gov.uk/technical-registry/Spreadsheet" />
     <skos:exactMatch rdf:resource="http://www.udfr.org/onto#SpreadsheetGenre" />
   </udfrs:GenreFacetType>
   <udfrs:GenreFacetType rdf:ID="WordProcessingDocument">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
-    <rdfs:subClassOf rdf:resource="Document" />
+    <rdfs:subClassOf rdf:resource="OfficeDocument" />
     <skos:closeMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#PaginatedTextDocument" />
     <skos:exactMatch rdf:resource="http://reference.data.gov.uk/technical-registry/WordprocessedText" />
     <skos:exactMatch rdf:resource="http://www.udfr.org/onto#DocumentGenre" />

--- a/pcdm-ext/file-format-types.rdf
+++ b/pcdm-ext/file-format-types.rdf
@@ -12,7 +12,7 @@
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
     <skos:exactMatch rdf:resource="http://vocab.getty.edu/aat/300026031" />
     <skos:exactMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Document" />
-    <skos:exactMatch rdf:resource="http://www.udfr.org/onto#DocumentGenre" />
+    <skos:narrowMatch rdf:resource="http://www.udfr.org/onto#DocumentGenre" />
   </udfrs:GenreFacetType>
   <udfrs:GenreFacetType rdf:ID="Archive">
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
@@ -147,6 +147,13 @@
     <skos:exactMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Spreadsheet" />
     <skos:exactMatch rdf:resource="http://reference.data.gov.uk/technical-registry/Spreadsheet" />
     <skos:exactMatch rdf:resource="http://www.udfr.org/onto#SpreadsheetGenre" />
+  </udfrs:GenreFacetType>
+  <udfrs:GenreFacetType rdf:ID="WordProcessingDocument">
+    <rdfs:isDefinedBy rdf:resource="http://pcdm.org/file-format-types#"/>
+    <rdfs:subClassOf rdf:resource="Document" />
+    <skos:closeMatch rdf:resource="http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#PaginatedTextDocument" />
+    <skos:exactMatch rdf:resource="http://reference.data.gov.uk/technical-registry/WordprocessedText" />
+    <skos:exactMatch rdf:resource="http://www.udfr.org/onto#DocumentGenre" />
   </udfrs:GenreFacetType>
   <!-- All media genres -->
   <udfrs:GenreFacetType rdf:ID="MediaList">


### PR DESCRIPTION
Building on addition of WordProcessingDocument, create a superclass called OfficeDocument that contains Presentation, Spreadsheet and WordProcessingDocument.
